### PR TITLE
Fire event for packets received from remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,24 @@ data:
   unit: 1
 ```
 
+# Events for Remote Commands
+In addition to processing remote commands to update cover states, the
+integration also fires explicit events of type
+`becker_remote_packet_received` for each command it receives from a remote.
+Those events can be used to trigger automations when remote buttons are pressed
+or for other custom purposes.
+
+Each event contains data about the remote unit, channel and the command
+that has been received, for instance:
+
+```yaml
+event_type: becker_remote_packet_received
+data:
+  unit: "12345"
+  channel: "1"
+  command: "up"
+```
+
 # Troubleshooting
 If you have any trouble follow these steps:
 - Restart Home Assistant after you have plugged in the USB stick

--- a/const.py
+++ b/const.py
@@ -20,6 +20,7 @@ DEVICE = "device"
 DEVICE_CLASS = "shutter"
 
 RECEIVE_MESSAGE = "receive_message"
+REMOTE_PACKET_EVENT = "remote_packet_received"
 
 CONF_CHANNEL = "channel"
 CONF_COVERS = "covers"


### PR DESCRIPTION
When a packet with a remote command is received, fire a Home Assistant event that contains data about the unit, channel and command.  This is done in addition to the existing logic for processing those commands (e.g. to sync cover state to remote commands), so that the events can be used separately for automations or other purposes if desired.