### PR TITLE
Fix warning, increase timeout, add working with new order number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Becker cover support for Home Assistant
 
 A native Home Assistant component to control Becker RF shutters with a Becker Centronic USB stick.
-It supports the Becker ***Centronic USB Stick*** with the Becker order number ***4035 200 041 0***.
+It works with the Becker ***Centronic USB Stick*** with the Becker order number ***4035 200 041 0*** and ***4035 000 041 0***.
 It works for the Becker ***Centronic*** roller shutters, blinds and sun protection as well as for Roto roof windows with RF remotes.  
 It is based on the work of [ole](https://github.com/ole1986) and [Nicolas Berthel](https://github.com/nicolasberthel).
 

--- a/cover.py
+++ b/cover.py
@@ -28,6 +28,7 @@ from homeassistant.helpers.event import (
     async_track_template_result,
 )
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import (
     CLOSED_POSITION,
@@ -250,8 +251,8 @@ class BeckerEntity(CoverEntity, RestoreEntity):
         if self._tc.current_position() is None:
             self._tc.set_position(100 - CLOSED_POSITION)
         # Setup callback on received packets
-        receive = self.hass.helpers.dispatcher.async_dispatcher_connect(
-            f"{DOMAIN}.{RECEIVE_MESSAGE}", self._async_message_received
+        receive = async_dispatcher_connect(
+            self.hass, f"{DOMAIN}.{RECEIVE_MESSAGE}", self._async_message_received
         )
         self.async_on_remove(receive)
         # Setup callback on template changes

--- a/pybecker/becker_helper.py
+++ b/pybecker/becker_helper.py
@@ -36,7 +36,7 @@ MESSAGE = re.compile(
 )
 
 COMMANDS = {b'0': 'RELEASE', b'1': 'HALT', b'2': 'UP', b'4': 'DOWN', b'8': 'TRAIN'}
-COMMUNICATION_TIMEOUT = 0.1
+COMMUNICATION_TIMEOUT = 0.3
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -244,7 +244,7 @@ class BeckerCommunicator(threading.Thread):
                     self._log(packet, "Sent packet: ")
 
             # Sleep for thread switch and wait time between packets
-            time.sleep(0.01)
+            time.sleep(0.1)
             # Ensure all packets in queue are send before thread is stopped
             if self._stop_flag.is_set() and self._write_queue.empty():
                 break


### PR DESCRIPTION
Fixed warning Detected that custom integration 'becker' accesses hass.helpers.dispatcher. This is deprecated and will stop working in Home Assistant 2024.11
and increased timeout as the original is too fast based on the already created code in develop2 branch main...develop2#diff-6580de2f03a85c3712efe5d5c83085820706406a008339cb7c073054fbc6a397R40

Added works with 4035 000 041 0 order number as per my testing - picture of the box at https://github.com/RainerStaude/hass-becker-component-plus-pybecker/issues/47