### PR TITLE
Fix for upstream refactor of helpers

### DIFF
--- a/rf_device.py
+++ b/rf_device.py
@@ -5,6 +5,9 @@ import logging
 import os
 
 import voluptuous as vol
+
+from homeassistant.helpers.dispatcher import dispatcher_send
+
 from .pybecker.becker import Becker
 from .pybecker.database import FILE_PATH, SQL_DB_FILE
 
@@ -100,7 +103,7 @@ class PyBecker:
     def callback(hass, packet):
         """Handle Becker device callback for received packets."""
         _LOGGER.debug("Received packet for dispatcher")
-        hass.helpers.dispatcher.dispatcher_send(f"{DOMAIN}.{RECEIVE_MESSAGE}", packet)
+        dispatcher_send(hass, f"{DOMAIN}.{RECEIVE_MESSAGE}", packet)
 
         # Also fire an explicit event that external applications can listen to
         # if that is of use to them.


### PR DESCRIPTION
`hass.helpers` has been [deprecated previously](https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers/) and was removed for 2025.05.

This fixes a piece of code that still relied on the old structure to use the new way as per that blog post.