### PR TITLE
Fix missing condition check in value_template processing

### DIFF
--- a/cover.py
+++ b/cover.py
@@ -499,7 +499,7 @@ class BeckerEntity(CoverEntity, RestoreEntity):
                 result = result.lower()
             if result in TEMPLATE_VALID_OPEN:
                 pos = OPEN_POSITION
-            elif TEMPLATE_VALID_CLOSE:
+            elif result in TEMPLATE_VALID_CLOSE:
                 pos = CLOSED_POSITION
             elif isinstance(result, int) or isinstance(result, float):
                 # Clip position to a range of 0 - 100


### PR DESCRIPTION
The elif branch on line 502 checks `elif TEMPLATE_VALID_CLOSE:` instead of `elif result in TEMPLATE_VALID_CLOSE:`, causing the condition to always evaluate True (non-empty list). This makes all subsequent branches (int/float handling, unknown state handling, and error logging) unreachable. Any template result not matching TEMPLATE_VALID_OPEN is silently treated as closed.

This issue was originally reported at issue https://github.com/RainerStaude/hass-becker-component-plus-pybecker/issues/38