### PR TITLE
Add entity_id definition of covers for usage in HA

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ cover:
   - platform: becker
     covers:
       # Use unique names for each cover like kitchen, bedroom or living_room
+      # This will define the entity_id in HA (e.g. cover.kitchen)
       kitchen:
         friendly_name: "Kitchen Cover"
         # Becker Centronic USB stick provides up to five units (1-5) with up to seven (1-7) channels

--- a/cover.py
+++ b/cover.py
@@ -278,8 +278,8 @@ class BeckerEntity(CoverEntity, RestoreEntity):
 
     @property
     def unique_id(self):
-        """Return the unique id of the device - the channel."""
-        return self._channel
+        """Return the unique id of the device reflecting the channel and entity_id."""
+        return f"becker_cover_{self._channel}_{self.entity_id}"
 
     @property
     def current_cover_position(self):

--- a/cover.py
+++ b/cover.py
@@ -165,7 +165,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
         covers.append(
             BeckerEntity(
-                PyBecker.becker, friendly_name, channel,
+                PyBecker.becker, device, friendly_name, channel,
                 state_template, remote_id, travel_time_down, travel_time_up,
                 intermediate_pos_up, intermediate_pos_down, intermediate_position,
                 tilt_intermediate, tilt_blind, tilt_time_blind,
@@ -179,13 +179,14 @@ class BeckerEntity(CoverEntity, RestoreEntity):
     """Representation of a Becker cover entity."""
 
     def __init__(
-        self, becker, name, channel,
+        self, becker, entity_id, name, channel,
         state_template, remote_id, travel_time_down, travel_time_up,
         intermediate_pos_up, intermediate_pos_down, intermediate_position,
         tilt_intermediate, tilt_blind, tilt_time_blind,
     ):
         """Init the Becker entity."""
         self._becker = becker
+        self.entity_id = f"cover.{entity_id}"
         self._name = name
         self._attr = dict()
         self._channel = channel


### PR DESCRIPTION
Hi Rainer,

thanks for the great work on this!

**Problem**
Currently, entities/covers are using their friendly_name to generate the HA entity_id. This causes issues when names contain special characters (like ä, ö, ü), which are not supported in Home Assistant entity_id fields. This may result in misrepresented IDs or difficulty referencing them in the UI and scripts.

**Solution**
This PR introduces a fix to ensure entity_id generation is sanitized and reproducible. This makes them comparable to other entities and ensures they work reliably within scripts and the UI.
I take the name of the device/cover defined in the config.yaml (e.g. kitchen or living_room) and pass it when initializing the BeckerEntity instance. The entity_id attribute is defined in the class Entity and inheritted via CoverEntity to the BeckerEntity.
Optional: The entity_id could be added optionally to the config.yaml file with the default as defined currently. But tbh I dont see the benefit.

Kind regards and all the best
Henning