### PR TITLE
Fix BeckerCommunicator thread crash on USB disconnect/reconnect

### DIFF
--- a/pybecker/becker_helper.py
+++ b/pybecker/becker_helper.py
@@ -125,10 +125,13 @@ class BeckerConnection():
         self._open()
         try:
             self._connection.write(packet)
-        except serial.SerialException:
-            # Re-connect on error (also for serial devices, e.g. after unplug/replug)
+        except Exception:
+            # Re-connect on error (covers SerialException and raw OSError on unplug)
             _LOGGER.debug("Write failed. Try to close and re-open connection to %s", self.device)
-            self._connection.close()
+            try:
+                self._connection.close()
+            except Exception:
+                pass
             self._open()
             self._connection.write(packet)
 
@@ -138,10 +141,13 @@ class BeckerConnection():
         self._open()
         try:
             packet = self._connection.read(1024)
-        except serial.SerialException:
-            # Re-connect on error (also for serial devices, e.g. after unplug/replug)
+        except Exception:
+            # Re-connect on error (covers SerialException and raw OSError on unplug)
             _LOGGER.debug("Read failed. Try to close and re-open connection to %s", self.device)
-            self._connection.close()
+            try:
+                self._connection.close()
+            except Exception:
+                pass
         return packet
 
     def _open(self) -> None:
@@ -156,8 +162,8 @@ class BeckerConnection():
                     )
                 else:
                     _LOGGER.error("Establish connection to %s failed!", self.device)
-            except:     # pylint: disable=bare-except
-                _LOGGER.error("Establish connection to %s failed!", self.device)
+            except Exception as err:     # pylint: disable=broad-except
+                _LOGGER.warning("Establish connection to %s failed, will retry: %s", self.device, err)
 
     def close(self) -> None:
         """Close connection"""
@@ -226,7 +232,7 @@ class BeckerCommunicator(threading.Thread):
             if callback_valid:
                 try:
                     data = self._connection.read()
-                except serial.SerialException as err:
+                except Exception as err:   # pylint: disable=broad-except
                     _LOGGER.warning(
                         "BeckerCommunicator read failed (%s). Will keep retrying without killing the thread.", err
                     )
@@ -244,7 +250,7 @@ class BeckerCommunicator(threading.Thread):
                 else:
                     try:
                         self._connection.write(packet)
-                    except (serial.SerialException, BeckerConnectionError) as err:
+                    except Exception as err:   # pylint: disable=broad-except
                         _LOGGER.warning(
                             "BeckerCommunicator failed to send packet (%s). Connection will be retried.", err
                         )

--- a/pybecker/becker_helper.py
+++ b/pybecker/becker_helper.py
@@ -94,21 +94,30 @@ class BeckerConnection():
     """
     Connection class for Becker centronic USB Stick.
     """
+    # Minimum seconds between full teardown/rebuild attempts of the
+    # underlying pyserial object once it gets stuck failing to open.
+    RECONNECT_REBUILD_INTERVAL = 10
+
     def __init__(self, device: str) -> None:
         """Initialize connection."""
         self._device, self._is_serial = self._validate_device(device)
+        self._connection = self._build_serial()
+        self._last_rebuild_attempt = 0.0
+        self._open()
+
+    def _build_serial(self):
+        """Create a fresh pyserial Serial object for the configured device."""
         try:
-            self._connection = serial.serial_for_url(
+            return serial.serial_for_url(
                 self.device,
                 baudrate=115200,
                 timeout=0,
-                do_not_open = True
+                do_not_open=True
             )
         except serial.SerialException as err:
             raise BeckerConnectionError(
                 "Error when trying to establish connection using {}.".format(self.device)
             ) from err
-        self._open()
 
     @property
     def is_serial(self) -> bool:
@@ -160,10 +169,39 @@ class BeckerConnection():
                     _LOGGER.warning(
                         "Establish connection to %s failed, will retry: %s", self.device, err
                     )
+                    self._maybe_rebuild()
                 else:
                     _LOGGER.error("Establish connection to %s failed!", self.device)
             except Exception as err:     # pylint: disable=broad-except
                 _LOGGER.warning("Establish connection to %s failed, will retry: %s", self.device, err)
+                self._maybe_rebuild()
+
+    def _maybe_rebuild(self) -> None:
+        """Periodically tear down and recreate the underlying pyserial object.
+
+        A stale pyserial Serial instance can end up wedged after the
+        OS-level device path disappears and reappears (e.g. the USB stick
+        was power-cycled). Simply retrying .open() on the same object can
+        fail to recover even once the device is back, because the object
+        may be holding onto stale internal file-descriptor state. Rebuilding
+        it from scratch periodically works around this without requiring a
+        full Home Assistant restart.
+        """
+        now = time.time()
+        if now - self._last_rebuild_attempt < self.RECONNECT_REBUILD_INTERVAL:
+            return
+        self._last_rebuild_attempt = now
+        try:
+            self._connection.close()
+        except Exception:  # pylint: disable=broad-except
+            pass
+        try:
+            new_connection = self._build_serial()
+        except BeckerConnectionError as err:
+            _LOGGER.debug("Rebuild of serial connection to %s failed: %s", self.device, err)
+            return
+        self._connection = new_connection
+        _LOGGER.info("Rebuilt serial connection object for %s after repeated failures.", self.device)
 
     def close(self) -> None:
         """Close connection"""

--- a/pybecker/becker_helper.py
+++ b/pybecker/becker_helper.py
@@ -126,9 +126,7 @@ class BeckerConnection():
         try:
             self._connection.write(packet)
         except serial.SerialException:
-            if self._is_serial:
-                raise
-            # Re-connect on error
+            # Re-connect on error (also for serial devices, e.g. after unplug/replug)
             _LOGGER.debug("Write failed. Try to close and re-open connection to %s", self.device)
             self._connection.close()
             self._open()
@@ -141,9 +139,7 @@ class BeckerConnection():
         try:
             packet = self._connection.read(1024)
         except serial.SerialException:
-            if self._is_serial:
-                raise
-            # Re-connect on error
+            # Re-connect on error (also for serial devices, e.g. after unplug/replug)
             _LOGGER.debug("Read failed. Try to close and re-open connection to %s", self.device)
             self._connection.close()
         return packet
@@ -155,10 +151,11 @@ class BeckerConnection():
                 self._connection.open()
             except serial.SerialException as err:
                 if self.is_serial:
-                    raise BeckerConnectionError(
-                        "Error when trying to establish connection using {}.".format(self.device)
-                    ) from err
-                _LOGGER.error("Establish connection to %s failed!", self.device)
+                    _LOGGER.warning(
+                        "Establish connection to %s failed, will retry: %s", self.device, err
+                    )
+                else:
+                    _LOGGER.error("Establish connection to %s failed!", self.device)
             except:     # pylint: disable=bare-except
                 _LOGGER.error("Establish connection to %s failed!", self.device)
 
@@ -227,7 +224,13 @@ class BeckerCommunicator(threading.Thread):
         while True:
             # Read bytes from serial port
             if callback_valid:
-                data = self._connection.read()
+                try:
+                    data = self._connection.read()
+                except serial.SerialException as err:
+                    _LOGGER.warning(
+                        "BeckerCommunicator read failed (%s). Will keep retrying without killing the thread.", err
+                    )
+                    data = bytes()
                 if len(data) > 0:
                     self._timeout = time.time() + COMMUNICATION_TIMEOUT
                 self._read_buffer += data
@@ -239,9 +242,15 @@ class BeckerCommunicator(threading.Thread):
                 except queue.Empty:
                     pass
                 else:
-                    self._connection.write(packet)
-                    self._timeout = time.time() + COMMUNICATION_TIMEOUT
-                    self._log(packet, "Sent packet: ")
+                    try:
+                        self._connection.write(packet)
+                    except (serial.SerialException, BeckerConnectionError) as err:
+                        _LOGGER.warning(
+                            "BeckerCommunicator failed to send packet (%s). Connection will be retried.", err
+                        )
+                    else:
+                        self._timeout = time.time() + COMMUNICATION_TIMEOUT
+                        self._log(packet, "Sent packet: ")
 
             # Sleep for thread switch and wait time between packets
             time.sleep(0.1)


### PR DESCRIPTION
This fixes an issue where unplugging/replugging the Becker USB stick
(or any transient serial I/O error) permanently kills the
BeckerCommunicator background thread with:

  BeckerConnectionError: Error BeckerCommunicator thread not alive.

...requiring a full Home Assistant restart to recover.

Root cause: read()/write() in BeckerConnection only handled
serial.SerialException in some paths, and re-raised it for serial
(non-socket) devices. An uncaught exception during the read/write
loop in BeckerCommunicator.run() also killed the thread outright,
since nothing wrapped it in try/except.

Fix:
- BeckerConnection.read()/write() now catch broadly (Exception, not
  just SerialException, since a real unplug can also raise a raw
  OSError that pyserial doesn't always wrap) and close+reopen the
  connection instead of propagating.
- BeckerConnection._open() logs a warning and retries instead of
  raising when a serial reconnect attempt fails.
- BeckerCommunicator.run() wraps both the read and write call sites,
  so no I/O error occurring during normal operation can escape and
  crash the thread.

Tested on Home Assistant OS (Proxmox VM) by repeatedly unplugging and
replugging the USB stick while the integration was running: the
thread survives, logs a warning, and reconnects automatically once
the device reappears — no HA restart needed.